### PR TITLE
Updated library for latest Haskell package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 test.log
 Examples/*
 dist/*
+dist-newstyle/*
+.hpc/*
 .gitignore
 .cabal-sandbox/*
 cabal.sandbox.config

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Examples/*
 dist/*
 dist-newstyle/*
 .hpc/*
+*.tix
 .gitignore
 .cabal-sandbox/*
 cabal.sandbox.config

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/*
 dist-newstyle/*
 .hpc/*
 *.tix
+.mutants/*
 .gitignore
 .cabal-sandbox/*
 cabal.sandbox.config

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ testrepl:
 	cabal repl --ghc-option='-package QuickCheck-2.6'
 
 hpcex:
-	- rm Examples/*.hi Examples/*.o *.tix tests
+	#- rm Examples/*.hi Examples/*.o *.tix tests
 	cabal build sample-test
 	./dist/build/sample-test/sample-test
 	./dist/build/mucheck/mucheck -tix sample-test.tix Examples/AssertCheckTest.hs

--- a/MuCheck.cabal
+++ b/MuCheck.cabal
@@ -60,9 +60,22 @@ library
 
 executable mucheck
   main-is:          Main.hs
+  other-modules:    Test.MuCheck
+                    Test.MuCheck.AnalysisSummary
+                    Test.MuCheck.Config
+                    Test.MuCheck.Interpreter
+                    Test.MuCheck.MuOp
+                    Test.MuCheck.Mutation
+                    Test.MuCheck.TestAdapter
+                    Test.MuCheck.TestAdapter.AssertCheck
+                    Test.MuCheck.TestAdapter.AssertCheckAdapter
+                    Test.MuCheck.Tix
+                    Test.MuCheck.Utils.Common
+                    Test.MuCheck.Utils.Print
+                    Test.MuCheck.Utils.Syb
   ghc-options:      -Wall
   build-depends:    base >=4 && <5,
-                    haskell-src-exts >=1.16,
+                    haskell-src-exts >=1.23,
                     syb >= 0.4.0,
                     time >= 1.4.0.1,
                     hint >= 0.3.1.0,
@@ -78,6 +91,7 @@ executable mucheck
 
 executable sample-test
   main-is:          Examples/Main.hs
+  other-modules:    Examples.AssertCheckTest
   build-depends:    base >=4 && <5,
                     MuCheck
   default-language: Haskell2010
@@ -87,20 +101,25 @@ test-suite spec
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Spec.hs
+  other-modules:    Test.MuCheck.MutationSpec
+                    Test.MuCheck.MutationSpec.Helpers
+                    Test.MuCheck.Utils.CommonSpec
+                    Test.MuCheck.Utils.PrintSpec
+                    Test.MuCheck.Utils.SybSpec
+                    Here
   default-language: Haskell2010
   build-depends:    base >=4 && <5,
-                    haskell-src-exts >=1.13,
+                    haskell-src-exts >= 1.23,
                     syb >= 0.4.0,
                     time >= 1.4.0.1,
                     hint >= 0.3.1.0,
                     mtl>=2.1.2,
                     hspec>= 2.0,
                     MuCheck,
-                    random >= 1.0.0,
+                    random >= 1.2.1,
                     directory >= 1.2.0.1,
                     temporary >= 1.1,
                     hashable >= 1.2,
                     hpc >= 0.5.1.1,
                     template-haskell >= 2.5.0
-  default-language: Haskell2010
-
+  build-tool-depends: hspec-discover:hspec-discover

--- a/MuCheck.cabal
+++ b/MuCheck.cabal
@@ -60,19 +60,6 @@ library
 
 executable mucheck
   main-is:          Main.hs
-  other-modules:    Test.MuCheck
-                    Test.MuCheck.AnalysisSummary
-                    Test.MuCheck.Config
-                    Test.MuCheck.Interpreter
-                    Test.MuCheck.MuOp
-                    Test.MuCheck.Mutation
-                    Test.MuCheck.TestAdapter
-                    Test.MuCheck.TestAdapter.AssertCheck
-                    Test.MuCheck.TestAdapter.AssertCheckAdapter
-                    Test.MuCheck.Tix
-                    Test.MuCheck.Utils.Common
-                    Test.MuCheck.Utils.Print
-                    Test.MuCheck.Utils.Syb
   ghc-options:      -Wall
   build-depends:    base >=4 && <5,
                     haskell-src-exts >=1.23,
@@ -101,12 +88,6 @@ test-suite spec
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Spec.hs
-  other-modules:    Test.MuCheck.MutationSpec
-                    Test.MuCheck.MutationSpec.Helpers
-                    Test.MuCheck.Utils.CommonSpec
-                    Test.MuCheck.Utils.PrintSpec
-                    Test.MuCheck.Utils.SybSpec
-                    Here
   default-language: Haskell2010
   build-depends:    base >=4 && <5,
                     haskell-src-exts >= 1.23,

--- a/src/Test/MuCheck/MuOp.hs
+++ b/src/Test/MuCheck/MuOp.hs
@@ -22,7 +22,7 @@ module Test.MuCheck.MuOp (MuOp
 import qualified Data.Generics as G
 import Control.Monad (MonadPlus, mzero)
 
-import Language.Haskell.Exts.Annotated(Module, Name, QName, QOp, Exp, Decl, Literal, GuardedRhs, Annotation, SrcSpanInfo(..), srcSpanStart, srcSpanEnd, prettyPrint, Pretty(), Annotated(..))
+import Language.Haskell.Exts(Module, Name, QName, QOp, Exp, Decl, Literal, GuardedRhs, Annotation, SrcSpanInfo(..), srcSpanStart, srcSpanEnd, prettyPrint, Pretty(), Annotated(..))
 
 -- | SrcSpanInfo wrapper
 type Module_ = Module SrcSpanInfo

--- a/src/Test/MuCheck/Mutation.hs
+++ b/src/Test/MuCheck/Mutation.hs
@@ -2,7 +2,7 @@
 -- | This module handles the mutation of different patterns.
 module Test.MuCheck.Mutation where
 
-import Language.Haskell.Exts.Annotated(Literal(Int, Char, Frac, String, PrimInt, PrimChar, PrimFloat, PrimDouble, PrimWord, PrimString),
+import Language.Haskell.Exts(Literal(Int, Char, Frac, String, PrimInt, PrimChar, PrimFloat, PrimDouble, PrimWord, PrimString),
         Exp(App, Var, If, Lit), QName(UnQual),
         Match(Match), Pat(PVar),
         Stmt(Qualifier), Module(Module),

--- a/src/Test/MuCheck/Utils/Common.hs
+++ b/src/Test/MuCheck/Utils/Common.hs
@@ -7,7 +7,6 @@ import Data.List
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Control.Monad (liftM)
 import qualified Data.Hashable as H
-import Debug.Trace
 
 -- | The `choose` function generates subsets of a given size
 choose :: [a] -> Int -> [[a]]
@@ -31,7 +30,7 @@ sample :: (RandomGen g) => g -> Int -> [t] -> [t]
 sample _ 0 _ = []
 sample _ n xs | length xs <= n = xs
 sample g n xs = val : sample g' (n - 1) (remElt idx xs)
-  where val = xs !! trace (show idx) idx
+  where val = xs !! idx
         (idx,g')  = randomR (0, length xs - 1) g
 
 -- | Wrapper around sample providing the random seed

--- a/src/Test/MuCheck/Utils/Common.hs
+++ b/src/Test/MuCheck/Utils/Common.hs
@@ -7,6 +7,7 @@ import Data.List
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Control.Monad (liftM)
 import qualified Data.Hashable as H
+import Debug.Trace
 
 -- | The `choose` function generates subsets of a given size
 choose :: [a] -> Int -> [[a]]
@@ -30,7 +31,7 @@ sample :: (RandomGen g) => g -> Int -> [t] -> [t]
 sample _ 0 _ = []
 sample _ n xs | length xs <= n = xs
 sample g n xs = val : sample g' (n - 1) (remElt idx xs)
-  where val = xs !! idx
+  where val = xs !! trace (show idx) idx
         (idx,g')  = randomR (0, length xs - 1) g
 
 -- | Wrapper around sample providing the random seed

--- a/src/Test/MuCheck/Utils/Helpers.hs
+++ b/src/Test/MuCheck/Utils/Helpers.hs
@@ -1,6 +1,6 @@
 -- | Helper module for easier visualization
 module Test.MuCheck.Utils.Helpers where
-import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts
 import Test.MuCheck.MuOp
 
 -- | Class to allow easier visualization of values without munging `show`

--- a/test/Test/MuCheck/MutationSpec.hs
+++ b/test/Test/MuCheck/MutationSpec.hs
@@ -9,7 +9,7 @@ import Test.MuCheck.Mutation
 import Control.Monad (MonadPlus, mplus, mzero)
 import Test.MuCheck.MuOp (mkMpMuOp, MuOp, (==>))
 import Data.Generics (GenericQ, mkQ, Data, Typeable, mkMp, listify)
-import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts
 import Here
 
 main :: IO ()

--- a/test/Test/MuCheck/MutationSpec/Helpers.hs
+++ b/test/Test/MuCheck/MutationSpec/Helpers.hs
@@ -3,7 +3,7 @@ module Test.MuCheck.MutationSpec.Helpers where
 import Here
 import Test.MuCheck.Utils.Helpers
 import Test.MuCheck.Mutation
-import Language.Haskell.Exts.Annotated
+import Language.Haskell.Exts
 _myprop = [e|
 module Prop where
 import Test.QuickCheck

--- a/test/Test/MuCheck/Utils/CommonSpec.hs
+++ b/test/Test/MuCheck/Utils/CommonSpec.hs
@@ -32,11 +32,11 @@ spec = do
 
   describe "sample" $ do
     it "must sample a given size subset" $ do
-      sample (mkStdGen 1) 2 [1,2,3,4] `shouldBe` [2, 3]
+      sample (mkStdGen 1) 2 [1,2,3,4] `shouldBe` [2, 4]
 
   describe "sampleF" $ do
     it "must sample a given fraction subset" $ do
-      sampleF (mkStdGen 1) 0.5 [1,2,3,4] `shouldBe` [2, 3]
+      sampleF (mkStdGen 1) 0.5 [1,2,3,4] `shouldBe` [2, 4]
 
   describe "coupling" $ do
     it "must sample a given fraction subset" $ do

--- a/test/Test/MuCheck/Utils/SybSpec.hs
+++ b/test/Test/MuCheck/Utils/SybSpec.hs
@@ -1,37 +1,36 @@
 module Test.MuCheck.Utils.SybSpec where
 
 import Test.Hspec
-import System.Random
 import qualified Test.MuCheck.Utils.Syb as S
 import Control.Monad (MonadPlus, mplus, mzero)
 import Test.MuCheck.MuOp (mkMpMuOp, MuOp)
 import Data.Generics (GenericQ, mkQ, Data, Typeable, mkMp, listify)
 import Language.Haskell.Exts
 
+tempSrcLoc = SrcLoc "<unknown>.hs" 15 1
+
 main :: IO ()
 main = hspec spec
 
+
 m1 a b = Match (SrcLoc "<unknown>.hs" 15 1)
-           (Ident a)
-           [PApp (UnQual (Ident b)) [],PLit Signless (Int 0)]
-           Nothing
-           (UnGuardedRhs (Lit (Int 1)))
-           (BDecls [])
+           (Ident tempSrcLoc a)
+           [PApp tempSrcLoc (UnQual tempSrcLoc (Ident tempSrcLoc b)) [],PLit tempSrcLoc (Signless tempSrcLoc) (Int tempSrcLoc 0 "0")]
+           (UnGuardedRhs tempSrcLoc (Lit tempSrcLoc (Int tempSrcLoc 1 "1")))
+           (Just (BDecls tempSrcLoc []))
 
-replM :: MonadPlus m => Name -> m Name
-replM (Ident "x") = return $ Ident "y"
+replM :: MonadPlus m => Name SrcLoc -> m (Name SrcLoc)
+replM (Ident l "x") = return $ Ident l "y"
 replM t = mzero
-
 
 spec :: Spec
 spec = do
   describe "once" $ do
     it "apply a function once on exp" $ do
-      (S.once (mkMp replM) (FunBind [m1 "y" "x"]) :: Maybe Decl) `shouldBe` Just (FunBind [m1 "y" "y"] :: Decl)
+      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "y" "x"]) :: Maybe (Decl SrcLoc)) `shouldBe` Just (FunBind tempSrcLoc [m1 "y" "y"] :: (Decl SrcLoc))
     it "apply a function just once" $ do
-      (S.once (mkMp replM) (FunBind [m1 "x" "x"]) :: Maybe Decl) `shouldBe` Just (FunBind [m1 "y" "x"] :: Decl)
+      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "x" "x"]) :: Maybe (Decl SrcLoc)) `shouldBe` Just (FunBind tempSrcLoc [m1 "y" "x"] :: (Decl SrcLoc))
     it "apply a function just once if possible" $ do
-      (S.once (mkMp replM) (FunBind [m1 "y" "y"]) :: Maybe Decl) `shouldBe` Nothing 
+      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "y" "y"]) :: Maybe (Decl SrcLoc)) `shouldBe` Nothing 
     it "should return all possibilities" $ do
-      (S.once (mkMp replM) (FunBind [m1 "x" "x"]) :: [Decl]) `shouldBe`  ([FunBind [m1 "y" "x"], FunBind [m1 "x" "y"]] :: [Decl])
-
+      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "x" "x"]) :: [(Decl SrcLoc)]) `shouldBe`  ([FunBind tempSrcLoc [m1 "y" "x"], FunBind tempSrcLoc [m1 "x" "y"]] :: [(Decl SrcLoc)])

--- a/test/Test/MuCheck/Utils/SybSpec.hs
+++ b/test/Test/MuCheck/Utils/SybSpec.hs
@@ -7,17 +7,16 @@ import Test.MuCheck.MuOp (mkMpMuOp, MuOp)
 import Data.Generics (GenericQ, mkQ, Data, Typeable, mkMp, listify)
 import Language.Haskell.Exts
 
-tempSrcLoc = SrcLoc "<unknown>.hs" 15 1
-
 main :: IO ()
 main = hspec spec
 
+dummySrcLoc = SrcLoc "<unknown>.hs" 15 1
 
-m1 a b = Match (SrcLoc "<unknown>.hs" 15 1)
-           (Ident tempSrcLoc a)
-           [PApp tempSrcLoc (UnQual tempSrcLoc (Ident tempSrcLoc b)) [],PLit tempSrcLoc (Signless tempSrcLoc) (Int tempSrcLoc 0 "0")]
-           (UnGuardedRhs tempSrcLoc (Lit tempSrcLoc (Int tempSrcLoc 1 "1")))
-           (Just (BDecls tempSrcLoc []))
+m1 a b = Match (dummySrcLoc)
+           (Ident dummySrcLoc a)
+           [PApp dummySrcLoc (UnQual dummySrcLoc (Ident dummySrcLoc b)) [],PLit dummySrcLoc (Signless dummySrcLoc) (Int dummySrcLoc 0 "0")]
+           (UnGuardedRhs dummySrcLoc (Lit dummySrcLoc (Int dummySrcLoc 1 "1")))
+           (Just (BDecls dummySrcLoc []))
 
 replM :: MonadPlus m => Name SrcLoc -> m (Name SrcLoc)
 replM (Ident l "x") = return $ Ident l "y"
@@ -27,10 +26,10 @@ spec :: Spec
 spec = do
   describe "once" $ do
     it "apply a function once on exp" $ do
-      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "y" "x"]) :: Maybe (Decl SrcLoc)) `shouldBe` Just (FunBind tempSrcLoc [m1 "y" "y"] :: (Decl SrcLoc))
+      (S.once (mkMp replM) (FunBind dummySrcLoc [m1 "y" "x"]) :: Maybe (Decl SrcLoc)) `shouldBe` Just (FunBind dummySrcLoc [m1 "y" "y"] :: (Decl SrcLoc))
     it "apply a function just once" $ do
-      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "x" "x"]) :: Maybe (Decl SrcLoc)) `shouldBe` Just (FunBind tempSrcLoc [m1 "y" "x"] :: (Decl SrcLoc))
+      (S.once (mkMp replM) (FunBind dummySrcLoc [m1 "x" "x"]) :: Maybe (Decl SrcLoc)) `shouldBe` Just (FunBind dummySrcLoc [m1 "y" "x"] :: (Decl SrcLoc))
     it "apply a function just once if possible" $ do
-      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "y" "y"]) :: Maybe (Decl SrcLoc)) `shouldBe` Nothing 
+      (S.once (mkMp replM) (FunBind dummySrcLoc [m1 "y" "y"]) :: Maybe (Decl SrcLoc)) `shouldBe` Nothing 
     it "should return all possibilities" $ do
-      (S.once (mkMp replM) (FunBind tempSrcLoc [m1 "x" "x"]) :: [(Decl SrcLoc)]) `shouldBe`  ([FunBind tempSrcLoc [m1 "y" "x"], FunBind tempSrcLoc [m1 "x" "y"]] :: [(Decl SrcLoc)])
+      (S.once (mkMp replM) (FunBind dummySrcLoc [m1 "x" "x"]) :: [(Decl SrcLoc)]) `shouldBe`  ([FunBind dummySrcLoc [m1 "y" "x"], FunBind dummySrcLoc [m1 "x" "y"]] :: [(Decl SrcLoc)])


### PR DESCRIPTION
The main changes are using Language.Haskell.Exts instead of Language.Haskell.Exts.Annotated, and then accounting for changes in the type definitions in Language.Haskell.Exts.

Additionally, I have modified the sample and sampleF test cases since it appears that the return value of [2,4] is correct.